### PR TITLE
feat(ethereum): remove logs inside consensus client

### DIFF
--- a/ethereum/consensus/client/http/get_attestations.go
+++ b/ethereum/consensus/client/http/get_attestations.go
@@ -10,12 +10,7 @@ import (
 
 // GetAttestations returns attestations known by the node but not necessarily incorporated into any block.
 func (c *Client) GetAttestations(ctx context.Context) (beaconphase0.Attestations, error) {
-	rv, err := c.getAttestations(ctx)
-	if err != nil {
-		c.logger.WithError(err).Errorf("GetAttestations failed")
-	}
-
-	return rv, err
+	return c.getAttestations(ctx)
 }
 
 func (c *Client) getAttestations(ctx context.Context) (beaconphase0.Attestations, error) {

--- a/ethereum/consensus/client/http/get_attester_slashings.go
+++ b/ethereum/consensus/client/http/get_attester_slashings.go
@@ -10,12 +10,7 @@ import (
 
 // GetAttesterSlashings returns attester slashings known by the node but not necessarily incorporated into any block.
 func (c *Client) GetAttesterSlashings(ctx context.Context) (beaconphase0.AttesterSlashings, error) {
-	rv, err := c.getAttesterSlashings(ctx)
-	if err != nil {
-		c.logger.WithError(err).Errorf("GetAttesterSlashings failed")
-	}
-
-	return rv, err
+	return c.getAttesterSlashings(ctx)
 }
 
 func (c *Client) getAttesterSlashings(ctx context.Context) (beaconphase0.AttesterSlashings, error) {

--- a/ethereum/consensus/client/http/get_block.go
+++ b/ethereum/consensus/client/http/get_block.go
@@ -10,14 +10,7 @@ import (
 
 // GetBlock returns block details for given block id.
 func (c *Client) GetBlock(ctx context.Context, blockID string) (*bellatrix.SignedBeaconBlock, error) {
-	rv, err := c.getBlock(ctx, blockID)
-	if err != nil {
-		c.logger.
-			WithField("block", blockID).
-			WithError(err).Errorf("GetBlock failed")
-	}
-
-	return rv, err
+	return c.getBlock(ctx, blockID)
 }
 
 func (c *Client) getBlock(ctx context.Context, blockID string) (*bellatrix.SignedBeaconBlock, error) {

--- a/ethereum/consensus/client/http/get_block_attestations.go
+++ b/ethereum/consensus/client/http/get_block_attestations.go
@@ -10,14 +10,7 @@ import (
 
 // GetBlockAttestations returns attestations included in requested block with given blockID
 func (c *Client) GetBlockAttestations(ctx context.Context, blockID string) (beaconphase0.Attestations, error) {
-	rv, err := c.getBlockAttestations(ctx, blockID)
-	if err != nil {
-		c.logger.
-			WithField("block", blockID).
-			WithError(err).Errorf("GetBlockAttestations failed")
-	}
-
-	return rv, err
+	return c.getBlockAttestations(ctx, blockID)
 }
 
 func (c *Client) getBlockAttestations(ctx context.Context, blockID string) (beaconphase0.Attestations, error) {

--- a/ethereum/consensus/client/http/get_block_header.go
+++ b/ethereum/consensus/client/http/get_block_header.go
@@ -11,14 +11,7 @@ import (
 
 // GetBlockHeader returns block header for given blockID
 func (c *Client) GetBlockHeader(ctx context.Context, blockID string) (*types.BeaconBlockHeader, error) {
-	rv, err := c.getBlockHeader(ctx, blockID)
-	if err != nil {
-		c.logger.
-			WithField("block", blockID).
-			WithError(err).Errorf("GetBlockHeader failed")
-	}
-
-	return rv, err
+	return c.getBlockHeader(ctx, blockID)
 }
 
 // GetBlockHeader returns block header for given blockID

--- a/ethereum/consensus/client/http/get_block_headers.go
+++ b/ethereum/consensus/client/http/get_block_headers.go
@@ -13,15 +13,7 @@ import (
 // GetBlockHeaders return block headers
 // Set slot and/or parentRoot to filter result (if nil no filter is applied)
 func (c *Client) GetBlockHeaders(ctx context.Context, slot *beaconcommon.Slot, parentRoot *beaconcommon.Root) ([]*types.BeaconBlockHeader, error) {
-	rv, err := c.getBlockHeaders(ctx, slot, parentRoot)
-	if err != nil {
-		c.logger.
-			WithField("slot", slot).
-			WithField("parent.root", parentRoot).
-			WithError(err).Errorf("GetBlockHeaders failed")
-	}
-
-	return rv, err
+	return c.getBlockHeaders(ctx, slot, parentRoot)
 }
 
 func (c *Client) getBlockHeaders(ctx context.Context, slot *beaconcommon.Slot, parentRoot *beaconcommon.Root) ([]*types.BeaconBlockHeader, error) {

--- a/ethereum/consensus/client/http/get_block_root.go
+++ b/ethereum/consensus/client/http/get_block_root.go
@@ -10,14 +10,7 @@ import (
 
 // GetBlockRoot returns hashTreeRoot of block
 func (c *Client) GetBlockRoot(ctx context.Context, blockID string) (*beaconcommon.Root, error) {
-	rv, err := c.getBlockRoot(ctx, blockID)
-	if err != nil {
-		c.logger.
-			WithField("block", blockID).
-			WithError(err).Errorf("GetBlockRoot failed")
-	}
-
-	return rv, err
+	return c.getBlockRoot(ctx, blockID)
 }
 
 func (c *Client) getBlockRoot(ctx context.Context, blockID string) (*beaconcommon.Root, error) {

--- a/ethereum/consensus/client/http/get_committees.go
+++ b/ethereum/consensus/client/http/get_committees.go
@@ -13,17 +13,7 @@ import (
 // GetCommittees returns the committees for the given state.
 // Set epoch and/or index and/or slot to filter result (if nil no filter is applied)
 func (c *Client) GetCommittees(ctx context.Context, stateID string, epoch *beaconcommon.Epoch, index *beaconcommon.CommitteeIndex, slot *beaconcommon.Slot) ([]*types.Committee, error) {
-	rv, err := c.getCommittees(ctx, stateID, epoch, index, slot)
-	if err != nil {
-		c.logger.
-			WithField("state", stateID).
-			WithField("epoch", epoch).
-			WithField("index", index).
-			WithField("slot", slot).
-			WithError(err).Errorf("GetCommittees failed")
-	}
-
-	return rv, err
+	return c.getCommittees(ctx, stateID, epoch, index, slot)
 }
 
 func (c *Client) getCommittees(ctx context.Context, stateID string, epoch *beaconcommon.Epoch, index *beaconcommon.CommitteeIndex, slot *beaconcommon.Slot) ([]*types.Committee, error) {

--- a/ethereum/consensus/client/http/get_genesis.go
+++ b/ethereum/consensus/client/http/get_genesis.go
@@ -11,12 +11,7 @@ import (
 
 // GetGenesis returns genesis block
 func (c *Client) GetGenesis(ctx context.Context) (*types.Genesis, error) {
-	rv, err := c.getGenesis(ctx)
-	if err != nil {
-		c.logger.WithError(err).Errorf("GetGenesis failed")
-	}
-
-	return rv, err
+	return c.getGenesis(ctx)
 }
 
 func (c *Client) getGenesis(ctx context.Context) (*types.Genesis, error) {

--- a/ethereum/consensus/client/http/get_node_version.go
+++ b/ethereum/consensus/client/http/get_node_version.go
@@ -9,12 +9,7 @@ import (
 
 // GetNodeVersion returns node's version contains informations about the node processing the request
 func (c *Client) GetNodeVersion(ctx context.Context) (string, error) {
-	rv, err := c.getNodeVersion(ctx)
-	if err != nil {
-		c.logger.WithError(err).Errorf("GetNodeVersion failed")
-	}
-
-	return rv, err
+	return c.getNodeVersion(ctx)
 }
 
 func (c *Client) getNodeVersion(ctx context.Context) (string, error) {

--- a/ethereum/consensus/client/http/get_proposer_slashings.go
+++ b/ethereum/consensus/client/http/get_proposer_slashings.go
@@ -10,12 +10,7 @@ import (
 
 // GetProposerSlashings returns proposer slashings known by the node but not necessarily incorporated into any block.
 func (c *Client) GetProposerSlashings(ctx context.Context) (beaconphase0.ProposerSlashings, error) {
-	rv, err := c.getProposerSlashings(ctx)
-	if err != nil {
-		c.logger.WithError(err).Errorf("GetProposerSlashings failed")
-	}
-
-	return rv, err
+	return c.getProposerSlashings(ctx)
 }
 
 func (c *Client) getProposerSlashings(ctx context.Context) (beaconphase0.ProposerSlashings, error) {

--- a/ethereum/consensus/client/http/get_spec.go
+++ b/ethereum/consensus/client/http/get_spec.go
@@ -11,12 +11,7 @@ import (
 
 // GetSpec returns Ethreum 2.0 specifications configuration used on the node.
 func (c *Client) GetSpec(ctx context.Context) (*beaconcommon.Spec, error) {
-	rv, err := c.getSpec(ctx)
-	if err != nil {
-		c.logger.WithError(err).Errorf("GetSpec failed")
-	}
-
-	return rv, err
+	return c.getSpec(ctx)
 }
 
 func (c *Client) getSpec(ctx context.Context) (*beaconcommon.Spec, error) {

--- a/ethereum/consensus/client/http/get_state_finality_checkpoints.go
+++ b/ethereum/consensus/client/http/get_state_finality_checkpoints.go
@@ -12,14 +12,7 @@ import (
 // GetStateFinalityCheckpoints returns finality checkpoints for state with given stateID
 // In case finality is not yet achieved returns epoch 0 and ZERO_HASH as root.
 func (c *Client) GetStateFinalityCheckpoints(ctx context.Context, stateID string) (*types.StateFinalityCheckpoints, error) {
-	rv, err := c.getStateFinalityCheckpoints(ctx, stateID)
-	if err != nil {
-		c.logger.
-			WithField("state", stateID).
-			WithError(err).Errorf("GetStateFinalityCheckpoints failed")
-	}
-
-	return rv, err
+	return c.getStateFinalityCheckpoints(ctx, stateID)
 }
 
 func (c *Client) getStateFinalityCheckpoints(ctx context.Context, stateID string) (*types.StateFinalityCheckpoints, error) {

--- a/ethereum/consensus/client/http/get_state_fork.go
+++ b/ethereum/consensus/client/http/get_state_fork.go
@@ -10,14 +10,7 @@ import (
 
 // GetStateFork returns Fork object for state with given stateID
 func (c *Client) GetStateFork(ctx context.Context, stateID string) (*beaconcommon.Fork, error) {
-	rv, err := c.getStateFork(ctx, stateID)
-	if err != nil {
-		c.logger.
-			WithField("state", stateID).
-			WithError(err).Errorf("GetStateFork failed")
-	}
-
-	return rv, err
+	return c.getStateFork(ctx, stateID)
 }
 
 func (c *Client) getStateFork(ctx context.Context, stateID string) (*beaconcommon.Fork, error) {

--- a/ethereum/consensus/client/http/get_state_root.go
+++ b/ethereum/consensus/client/http/get_state_root.go
@@ -10,14 +10,7 @@ import (
 
 // GetStateRoot returns State root for state with given stateID
 func (c *Client) GetStateRoot(ctx context.Context, stateID string) (*beaconcommon.Root, error) {
-	rv, err := c.getStateRoot(ctx, stateID)
-	if err != nil {
-		c.logger.
-			WithField("state", stateID).
-			WithError(err).Errorf("GetStateFork failed")
-	}
-
-	return rv, err
+	return c.getStateRoot(ctx, stateID)
 }
 
 func (c *Client) getStateRoot(ctx context.Context, stateID string) (*beaconcommon.Root, error) {

--- a/ethereum/consensus/client/http/get_sync_committees.go
+++ b/ethereum/consensus/client/http/get_sync_committees.go
@@ -13,15 +13,7 @@ import (
 // GetSyncCommittees returns the sync committees for given stateID
 // Set epoch to filter result (if nil no filter is applied)
 func (c *Client) GetSyncCommittees(ctx context.Context, stateID string, epoch *beaconcommon.Epoch) (*types.SyncCommittees, error) {
-	rv, err := c.getSyncCommittees(ctx, stateID, epoch)
-	if err != nil {
-		c.logger.
-			WithField("state", stateID).
-			WithField("epoch", epoch).
-			WithError(err).Errorf("GetSyncCommittees failed")
-	}
-
-	return rv, err
+	return c.getSyncCommittees(ctx, stateID, epoch)
 }
 
 func (c *Client) getSyncCommittees(ctx context.Context, stateID string, epoch *beaconcommon.Epoch) (*types.SyncCommittees, error) {

--- a/ethereum/consensus/client/http/get_validator.go
+++ b/ethereum/consensus/client/http/get_validator.go
@@ -11,15 +11,7 @@ import (
 
 // GetValidator returns validator specified by stateID and validatorID
 func (c *Client) GetValidator(ctx context.Context, stateID, validatorID string) (*types.Validator, error) {
-	rv, err := c.getValidator(ctx, stateID, validatorID)
-	if err != nil {
-		c.logger.
-			WithField("state", stateID).
-			WithField("validator.id", validatorID).
-			WithError(err).Errorf("GetValidator failed")
-	}
-
-	return rv, err
+	return c.getValidator(ctx, stateID, validatorID)
 }
 
 func (c *Client) getValidator(ctx context.Context, stateID, validatorID string) (*types.Validator, error) {

--- a/ethereum/consensus/client/http/get_validator_balances.go
+++ b/ethereum/consensus/client/http/get_validator_balances.go
@@ -12,15 +12,7 @@ import (
 // GetValidatorBalances returns list of validator balances.
 // Set validatorsIDs to filter validator result (if empty no filter is applied)
 func (c *Client) GetValidatorBalances(ctx context.Context, stateID string, validatorIDs []string) ([]*types.ValidatorBalance, error) {
-	rv, err := c.getValidatorBalances(ctx, stateID, validatorIDs)
-	if err != nil {
-		c.logger.
-			WithField("state", stateID).
-			WithField("validators", validatorIDs).
-			WithError(err).Errorf("GetValidatorBalances failed")
-	}
-
-	return rv, err
+	return c.getValidatorBalances(ctx, stateID, validatorIDs)
 }
 
 func (c *Client) getValidatorBalances(ctx context.Context, stateID string, validatorIDs []string) ([]*types.ValidatorBalance, error) {

--- a/ethereum/consensus/client/http/get_validators.go
+++ b/ethereum/consensus/client/http/get_validators.go
@@ -13,16 +13,7 @@ import (
 // GetValidators returns list of validators
 // Set validatorsIDs and/or statuses to filter result (if empty no filter is applied)
 func (c *Client) GetValidators(ctx context.Context, stateID string, validatorIDs, statuses []string) ([]*types.Validator, error) {
-	rv, err := c.getValidators(ctx, stateID, validatorIDs, statuses)
-	if err != nil {
-		c.logger.
-			WithField("state", stateID).
-			WithField("validator.ids", validatorIDs).
-			WithField("statuses", statuses).
-			WithError(err).Errorf("GetValidators failed")
-	}
-
-	return rv, err
+	return c.getValidators(ctx, stateID, validatorIDs, statuses)
 }
 
 func (c *Client) getValidators(ctx context.Context, stateID string, validatorIDs, statuses []string) ([]*types.Validator, error) {

--- a/ethereum/consensus/client/http/get_voluntary_exits.go
+++ b/ethereum/consensus/client/http/get_voluntary_exits.go
@@ -10,12 +10,7 @@ import (
 
 // GetVoluntaryExits returns voluntary exits known by the node but not necessarily incorporated into any block.
 func (c *Client) GetVoluntaryExits(ctx context.Context) (beaconphase0.VoluntaryExits, error) {
-	rv, err := c.getVoluntaryExits(ctx)
-	if err != nil {
-		c.logger.WithError(err).Errorf("GetVoluntaryExits failed")
-	}
-
-	return rv, err
+	return c.getVoluntaryExits(ctx)
 }
 
 func (c *Client) getVoluntaryExits(ctx context.Context) (beaconphase0.VoluntaryExits, error) {


### PR DESCRIPTION
Currently, users of this package are forced to emit logs when a consensus client call returns an error. Instead, the package user should determine when to emit logs (error or otherwise).