### PR TITLE
Feat: add new pectra method - getPendingPartialWithdrawals

### DIFF
--- a/ethereum/consensus/client/client.go
+++ b/ethereum/consensus/client/client.go
@@ -103,6 +103,9 @@ type BeaconClient interface {
 
 	// SubmitSignedVoluntaryExit submits a signed voluntary exit to the beacon node.
 	SubmitSignedVoluntaryExit(ctx context.Context, epoch beaconcommon.Epoch, validatorIdx uint64, signature string) (string, error)
+
+	// GetPendingPartialWithdrawals returns pending partial withdrawals [Pectra]
+	GetPendingPartialWithdrawals(ctx context.Context) ([]*types.PendingPartialWithdrawal, error)
 }
 
 type NodeClient interface {

--- a/ethereum/consensus/client/client.go
+++ b/ethereum/consensus/client/client.go
@@ -105,7 +105,7 @@ type BeaconClient interface {
 	SubmitSignedVoluntaryExit(ctx context.Context, epoch beaconcommon.Epoch, validatorIdx uint64, signature string) (string, error)
 
 	// GetPendingPartialWithdrawals returns pending partial withdrawals [Pectra]
-	GetPendingPartialWithdrawals(ctx context.Context) ([]*types.PendingPartialWithdrawal, error)
+	GetPendingPartialWithdrawals(ctx context.Context, stateID string) ([]*types.PendingPartialWithdrawal, error)
 }
 
 type NodeClient interface {

--- a/ethereum/consensus/client/http/get_pending_partial_withdrawals.go
+++ b/ethereum/consensus/client/http/get_pending_partial_withdrawals.go
@@ -1,0 +1,57 @@
+package eth2http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/kilnfi/go-utils/ethereum/consensus/types"
+)
+
+func (c *Client) GetPendingPartialWithdrawals(ctx context.Context) ([]*types.PendingPartialWithdrawal, error) {
+	rv, err := c.getPendingPartialWithdrawals(ctx)
+	if err != nil {
+		c.logger.WithError(err).Errorf("GetPendingPartialWithdrawals failed")
+	}
+
+	return rv, err
+}
+
+func (c *Client) getPendingPartialWithdrawals(ctx context.Context) ([]*types.PendingPartialWithdrawal, error) {
+
+	req, err := newGetPendingPartialWithdrawalsRequest(ctx)
+	if err != nil {
+		return nil, autorest.NewErrorWithError(err, "eth2http.Client", "GetPendingPartialWithdrawals", nil, "Failure preparing request")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, autorest.NewErrorWithError(err, "eth2http.Client", "GetPendingPartialWithdrawals", resp, "Failure sending request")
+	}
+
+	result, err := inspectGetPendingPartialWithdrawalsResponse(resp)
+	if err != nil {
+		return nil, autorest.NewErrorWithError(err, "eth2http.Client", "GetPendingPartialWithdrawals", resp, "Invalid response")
+	}
+
+	return result, nil
+
+}
+
+func newGetPendingPartialWithdrawalsRequest(ctx context.Context) (*http.Request, error) {
+	return autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithPath("eth/v1/beacon/states/head/pending_partial_withdrawals"),
+	).Prepare(newRequest(ctx))
+}
+
+func inspectGetPendingPartialWithdrawalsResponse(resp *http.Response) ([]*types.PendingPartialWithdrawal, error) {
+	var pendingPartialWithdrawals types.WithdrawalsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pendingPartialWithdrawals); err != nil {
+		return nil, fmt.Errorf("failed to decode pending partial withdrawals: %w", err)
+	}
+
+	return pendingPartialWithdrawals.Data, nil
+}

--- a/ethereum/consensus/client/http/get_pending_partial_withdrawals.go
+++ b/ethereum/consensus/client/http/get_pending_partial_withdrawals.go
@@ -8,8 +8,8 @@ import (
 	"github.com/kilnfi/go-utils/ethereum/consensus/types"
 )
 
-func (c *Client) GetPendingPartialWithdrawals(ctx context.Context) ([]*types.PendingPartialWithdrawal, error) {
-	rv, err := c.getPendingPartialWithdrawals(ctx)
+func (c *Client) GetPendingPartialWithdrawals(ctx context.Context, stateID string) ([]*types.PendingPartialWithdrawal, error) {
+	rv, err := c.getPendingPartialWithdrawals(ctx, stateID)
 	if err != nil {
 		c.logger.WithError(err).Errorf("GetPendingPartialWithdrawals failed")
 	}
@@ -17,9 +17,8 @@ func (c *Client) GetPendingPartialWithdrawals(ctx context.Context) ([]*types.Pen
 	return rv, err
 }
 
-func (c *Client) getPendingPartialWithdrawals(ctx context.Context) ([]*types.PendingPartialWithdrawal, error) {
-
-	req, err := newGetPendingPartialWithdrawalsRequest(ctx)
+func (c *Client) getPendingPartialWithdrawals(ctx context.Context, stateID string) ([]*types.PendingPartialWithdrawal, error) {
+	req, err := newGetPendingPartialWithdrawalsRequest(ctx, stateID)
 	if err != nil {
 		return nil, autorest.NewErrorWithError(err, "eth2http.Client", "GetPendingPartialWithdrawals", nil, "Failure preparing request")
 	}
@@ -35,13 +34,16 @@ func (c *Client) getPendingPartialWithdrawals(ctx context.Context) ([]*types.Pen
 	}
 
 	return result, nil
-
 }
 
-func newGetPendingPartialWithdrawalsRequest(ctx context.Context) (*http.Request, error) {
+func newGetPendingPartialWithdrawalsRequest(ctx context.Context, stateID string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"stateID": autorest.Encode("path", stateID),
+	}
+
 	return autorest.CreatePreparer(
 		autorest.AsGet(),
-		autorest.WithPath("eth/v1/beacon/states/head/pending_partial_withdrawals"),
+		autorest.WithPathParameters("eth/v1/beacon/states/{stateID}/pending_partial_withdrawals", pathParameters),
 	).Prepare(newRequest(ctx))
 }
 

--- a/ethereum/consensus/client/http/get_pending_partial_withdrawals.go
+++ b/ethereum/consensus/client/http/get_pending_partial_withdrawals.go
@@ -2,8 +2,6 @@ package eth2http
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -47,11 +45,16 @@ func newGetPendingPartialWithdrawalsRequest(ctx context.Context) (*http.Request,
 	).Prepare(newRequest(ctx))
 }
 
+type getPendingPartialWithdrawalsResponseMsg struct {
+	Data []*types.PendingPartialWithdrawal `json:"data"`
+}
+
 func inspectGetPendingPartialWithdrawalsResponse(resp *http.Response) ([]*types.PendingPartialWithdrawal, error) {
-	var pendingPartialWithdrawals types.WithdrawalsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&pendingPartialWithdrawals); err != nil {
-		return nil, fmt.Errorf("failed to decode pending partial withdrawals: %w", err)
+	msg := new(getPendingPartialWithdrawalsResponseMsg)
+	err := inspectResponse(resp, msg)
+	if err != nil {
+		return nil, err
 	}
 
-	return pendingPartialWithdrawals.Data, nil
+	return msg.Data, nil
 }

--- a/ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go
+++ b/ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go
@@ -42,7 +42,7 @@ func testGetPendingPartialWithdrawalsStatusOK(t *testing.T, c *Client, mockCli *
 
 	mockCli.EXPECT().Gock(req)
 
-	withdrawals, err := c.GetPendingPartialWithdrawals(context.Background())
+	withdrawals, err := c.GetPendingPartialWithdrawals(context.Background(), "head")
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(withdrawals))
@@ -58,7 +58,7 @@ func testGetPendingPartialWithdrawalsStatus400(t *testing.T, c *Client, mockCli 
 
 	mockCli.EXPECT().Gock(req)
 
-	_, err := c.GetPendingPartialWithdrawals(context.Background())
+	_, err := c.GetPendingPartialWithdrawals(context.Background(), "head")
 
 	require.Error(t, err)
 }

--- a/ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go
+++ b/ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go
@@ -1,0 +1,64 @@
+//go:build !integration
+// +build !integration
+
+package eth2http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	httptestutils "github.com/kilnfi/go-utils/net/http/testutils"
+)
+
+func TestGetPendingPartialWithdrawals(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCli := httptestutils.NewMockSender(ctrl)
+	c := NewClientFromClient(mockCli)
+
+	t.Run("StatusOK", func(t *testing.T) { testGetPendingPartialWithdrawalsStatusOK(t, c, mockCli) })
+	t.Run("Status400", func(t *testing.T) { testGetPendingPartialWithdrawalsStatus400(t, c, mockCli) })
+}
+
+func testGetPendingPartialWithdrawalsStatusOK(t *testing.T, c *Client, mockCli *httptestutils.MockSender) {
+	req := httptestutils.NewGockRequest()
+	req.Get("/eth/v1/beacon/states/head/pending_partial_withdrawals").
+		Reply(200).
+		JSON([]byte(`{
+			"data": [
+				{
+					"validator_index": "123",
+					"address": "0x1234567890123456789012345678901234567890",
+					"withdrawable_epoch": "123456"
+				}
+			]
+		}`))
+
+	mockCli.EXPECT().Gock(req)
+
+	withdrawals, err := c.GetPendingPartialWithdrawals(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(withdrawals))
+	assert.Equal(t, uint64(123), withdrawals[0].ValidatorIndex)
+	assert.Equal(t, common.HexToAddress("0x1234567890123456789012345678901234567890"), withdrawals[0].Address)
+	assert.Equal(t, uint64(123456), withdrawals[0].WithdrawableEpoch)
+}
+
+func testGetPendingPartialWithdrawalsStatus400(t *testing.T, c *Client, mockCli *httptestutils.MockSender) {
+	req := httptestutils.NewGockRequest()
+	req.Get("/eth/v1/beacon/states/head/pending_partial_withdrawals").
+		Reply(400)
+
+	mockCli.EXPECT().Gock(req)
+
+	_, err := c.GetPendingPartialWithdrawals(context.Background())
+
+	require.Error(t, err)
+}

--- a/ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go
+++ b/ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go
@@ -33,9 +33,9 @@ func testGetPendingPartialWithdrawalsStatusOK(t *testing.T, c *Client, mockCli *
 		JSON([]byte(`{
 			"data": [
 				{
-					"validator_index": "123",
+					"validator_index": 123,
 					"address": "0x1234567890123456789012345678901234567890",
-					"withdrawable_epoch": "123456"
+					"withdrawable_epoch": 123456
 				}
 			]
 		}`))

--- a/ethereum/consensus/types/withdrawals.go
+++ b/ethereum/consensus/types/withdrawals.go
@@ -7,10 +7,3 @@ type PendingPartialWithdrawal struct {
 	Address           common.Address `json:"address"`
 	WithdrawableEpoch uint64         `json:"withdrawable_epoch"`
 }
-
-type WithdrawalsResponse struct {
-	Version             string                      `json:"version"`
-	ExecutionOptimistic bool                        `json:"execution_optimistic"`
-	Finalized           string                      `json:"finalized"`
-	Data                []*PendingPartialWithdrawal `json:"data"`
-}

--- a/ethereum/consensus/types/withdrawals.go
+++ b/ethereum/consensus/types/withdrawals.go
@@ -1,0 +1,16 @@
+package types
+
+import "github.com/ethereum/go-ethereum/common"
+
+type PendingPartialWithdrawal struct {
+	ValidatorIndex    uint64         `json:"validator_index"`
+	Address           common.Address `json:"address"`
+	WithdrawableEpoch uint64         `json:"withdrawable_epoch"`
+}
+
+type WithdrawalsResponse struct {
+	Version             string                      `json:"version"`
+	ExecutionOptimistic bool                        `json:"execution_optimistic"`
+	Finalized           string                      `json:"finalized"`
+	Data                []*PendingPartialWithdrawal `json:"data"`
+}


### PR DESCRIPTION
This pull request introduces functionality to retrieve pending partial withdrawals from the Ethereum Beacon Node API. The changes include updates to the `BeaconClient` interface, the addition of a new HTTP client method, corresponding unit tests, and new data types for handling withdrawal responses.

### API Enhancements:
* Added a new method `GetPendingPartialWithdrawals` to the `BeaconClient` interface for fetching pending partial withdrawals. (`ethereum/consensus/client/client.go`, [ethereum/consensus/client/client.goR106-R108](diffhunk://#diff-45ddf061192c13eee5a4ec7cc7d0d5ca7d7726812245883414fa91331dc9361dR106-R108))
* Implemented the `GetPendingPartialWithdrawals` method in the HTTP client, including request preparation and response handling logic. (`ethereum/consensus/client/http/get_pending_partial_withdrawals.go`, [ethereum/consensus/client/http/get_pending_partial_withdrawals.goR1-R57](diffhunk://#diff-8debf68dec2609271b1441a3cc14858428db06756a8ada69ccaac9ce0360aaaaR1-R57))

### Testing:
* Added unit tests for the `GetPendingPartialWithdrawals` method to validate successful and error responses. (`ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go`, [ethereum/consensus/client/http/get_pending_partial_withdrawals_test.goR1-R64](diffhunk://#diff-b40c3bae6196b52895ab4e0592467b42430ce1038184be186ee3928d3d5a93eeR1-R64))

### Data Structures:
* Introduced `PendingPartialWithdrawal` and `WithdrawalsResponse` types to represent withdrawal data and API responses. (`ethereum/consensus/types/withdrawals.go`, [ethereum/consensus/types/withdrawals.goR1-R16](diffhunk://#diff-8806fcd3c5bbd3b3fa498321faa3a4aaf8fc00b9598af552a6cbeaac42c68349R1-R16))
This pull request introduces a new feature to retrieve pending partial withdrawals from the Ethereum beacon node. It includes updates to the client interface, the implementation of the new functionality, and associated tests and data structures.

### New Feature: Retrieve Pending Partial Withdrawals

* **Interface Update**: Added the `GetPendingPartialWithdrawals` method to the `BeaconClient` interface to retrieve pending partial withdrawals. (`ethereum/consensus/client/client.go`)

* **Implementation**: 
  - Created the `GetPendingPartialWithdrawals` method in the `eth2http.Client` to handle HTTP requests and responses for fetching pending partial withdrawals. (`ethereum/consensus/client/http/get_pending_partial_withdrawals.go`)
  - Added helper functions to prepare the HTTP request and inspect the response. (`ethereum/consensus/client/http/get_pending_partial_withdrawals.go`)

* **Testing**: 
  - Added unit tests for `GetPendingPartialWithdrawals` to validate successful responses (status 200) and error handling (status 400). (`ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go`)

* **Data Structures**: Defined `PendingPartialWithdrawal` and `WithdrawalsResponse` types to represent the data structure of pending partial withdrawals and their response format. (`ethereum/consensus/types/withdrawals.go`)