### PR TITLE
fix: get pending withdrawals

### DIFF
--- a/ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go
+++ b/ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,9 +32,9 @@ func testGetPendingPartialWithdrawalsStatusOK(t *testing.T, c *Client, mockCli *
 		JSON([]byte(`{
 			"data": [
 				{
-					"validator_index": 123,
-					"address": "0x1234567890123456789012345678901234567890",
-					"withdrawable_epoch": 123456
+					"validator_index": "123",
+					"amount": "32000000000",
+					"withdrawable_epoch": "123456"
 				}
 			]
 		}`))
@@ -46,9 +45,9 @@ func testGetPendingPartialWithdrawalsStatusOK(t *testing.T, c *Client, mockCli *
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(withdrawals))
-	assert.Equal(t, uint64(123), withdrawals[0].ValidatorIndex)
-	assert.Equal(t, common.HexToAddress("0x1234567890123456789012345678901234567890"), withdrawals[0].Address)
-	assert.Equal(t, uint64(123456), withdrawals[0].WithdrawableEpoch)
+	assert.Equal(t, "123", withdrawals[0].ValidatorIndex)
+	assert.Equal(t, "32000000000", withdrawals[0].Amount)
+	assert.Equal(t, "123456", withdrawals[0].WithdrawableEpoch)
 }
 
 func testGetPendingPartialWithdrawalsStatus400(t *testing.T, c *Client, mockCli *httptestutils.MockSender) {

--- a/ethereum/consensus/types/withdrawals.go
+++ b/ethereum/consensus/types/withdrawals.go
@@ -2,6 +2,6 @@ package types
 
 type PendingPartialWithdrawal struct {
 	ValidatorIndex    string `json:"validator_index"`
-	Amount            string `json:"amount"`
+	Amount            string `json:"amount"` // Amount represents the amount to be withdrawn, specified in Gwei.
 	WithdrawableEpoch string `json:"withdrawable_epoch"`
 }

--- a/ethereum/consensus/types/withdrawals.go
+++ b/ethereum/consensus/types/withdrawals.go
@@ -1,9 +1,7 @@
 package types
 
-import "github.com/ethereum/go-ethereum/common"
-
 type PendingPartialWithdrawal struct {
-	ValidatorIndex    uint64         `json:"validator_index"`
-	Address           common.Address `json:"address"`
-	WithdrawableEpoch uint64         `json:"withdrawable_epoch"`
+	ValidatorIndex    string `json:"validator_index"`
+	Amount            string `json:"amount"`
+	WithdrawableEpoch string `json:"withdrawable_epoch"`
 }


### PR DESCRIPTION
This pull request updates the `PendingPartialWithdrawal` structure and associated test cases to align with changes in the API response format. The most notable changes include replacing numeric fields with string fields and removing the `Address` field.

### Changes to data structure:

* [`ethereum/consensus/types/withdrawals.go`](diffhunk://#diff-8806fcd3c5bbd3b3fa498321faa3a4aaf8fc00b9598af552a6cbeaac42c68349L3-R6): Updated the `PendingPartialWithdrawal` struct to use string types for `ValidatorIndex`, `Amount`, and `WithdrawableEpoch`, and removed the `Address` field.

### Changes to test cases:

* [`ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go`](diffhunk://#diff-b40c3bae6196b52895ab4e0592467b42430ce1038184be186ee3928d3d5a93eeL36-R37): Updated the mock API response in `testGetPendingPartialWithdrawalsStatusOK` to match the new structure, replacing numeric values with strings and removing the `Address` field.
* [`ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go`](diffhunk://#diff-b40c3bae6196b52895ab4e0592467b42430ce1038184be186ee3928d3d5a93eeL49-R50): Adjusted assertions in `testGetPendingPartialWithdrawalsStatusOK` to validate the updated string fields and removed checks for the `Address` field.

### Code cleanup:

* [`ethereum/consensus/client/http/get_pending_partial_withdrawals_test.go`](diffhunk://#diff-b40c3bae6196b52895ab4e0592467b42430ce1038184be186ee3928d3d5a93eeL10): Removed the unused import of `github.com/ethereum/go-ethereum/common`.