### PR TITLE
chore: bump to go1.26.2 for CVE

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
       - '**.md'
       - .gitignore
 env:
-  GO_VERSION: "1.26.1"
+  GO_VERSION: "1.26.2"
 jobs:
   unit-tests:
     name: 'Unit tests in ${{ matrix.os }}'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kilnfi/go-utils
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/Azure/go-autorest/autorest v0.11.30 //deprecated


### PR DESCRIPTION
## Summary
- Bumps Go version from 1.26.1 to 1.26.2 to address CVE

## Files changed
- `go.mod`
- `.github/workflows/pr.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development toolchain to the latest stable version for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->