### PR TITLE
chore: read go version from go.mod in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: 'Check out project files'
         uses: actions/checkout@v6
         with:
@@ -35,6 +36,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
         with:
           submodules: recursive
@@ -54,6 +56,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: 'Run linting checks'
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,15 +13,15 @@ jobs:
         os: ["ubuntu-24.04"]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: 'Check out project files'
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - name: 'Setup go'
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
-      - name: 'Check out project files'
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
       - name: 'Run unit tests and generage HTML coverage report'
         run: |
           make unit-test-cov
@@ -33,13 +33,13 @@ jobs:
         os: ["ubuntu-24.04"]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
       - name: 'Pull postgres 14.4 docker image so it is available for integeration test'
         run: |
           docker pull postgres:14.4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,8 +4,6 @@ on:
     paths-ignore:
       - '**.md'
       - .gitignore
-env:
-  GO_VERSION: "1.26.1"
 jobs:
   unit-tests:
     name: 'Unit tests in ${{ matrix.os }}'
@@ -15,10 +13,10 @@ jobs:
         os: ["ubuntu-24.04"]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: 'Setup go ${{ env.GO_VERSION }}'
+      - name: 'Setup go'
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: 'Check out project files'
         uses: actions/checkout@v6
         with:
@@ -36,7 +34,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - uses: actions/checkout@v6
         with:
           submodules: recursive
@@ -54,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
       - name: 'Run linting checks'
         uses: golangci/golangci-lint-action@v9

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kilnfi/go-utils
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Azure/go-autorest/autorest v0.11.30 //deprecated


### PR DESCRIPTION
Replace `GO_VERSION` env var and hardcoded `go-version` pins in all `setup-go` steps with `go-version-file: go.mod` so bumping the Go version only requires updating `go.mod`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Go version management in CI so builds, tests, and linting use the module's Go version.
  * Adjusted CI job sequencing and environment setup for more reliable test and lint runs; caching for lint is preserved.
  * Bumped module Go directive to Go 1.26.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlluvialFinance/go-utils/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->