### PR TITLE
chore: run CI on AlluvialFinance BCE self-hosted runners (BS-4280)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - alluvial-finance-k8s-runners

--- a/.github/actions/setup-runner-tools/action.yml
+++ b/.github/actions/setup-runner-tools/action.yml
@@ -1,0 +1,15 @@
+name: Setup runner build tooling
+description: >-
+  Install host build tools that are not present on the minimal self-hosted
+  runner image: build-essential (make/gcc/g++) and Node.js. Go is provided by
+  actions/setup-go and python3 is already present on the image.
+runs:
+  using: composite
+  steps:
+    - name: Install build-essential
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+      with:
+        node-version: '24'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: alluvial-finance-k8s-runners
     steps:
       - name: 'Check out project files'
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,13 +10,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04"]
+        os: ["alluvial-finance-k8s-runners"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out project files'
         uses: actions/checkout@v6
         with:
           submodules: recursive
+      - uses: ./.github/actions/setup-runner-tools
       - name: 'Setup go'
         uses: actions/setup-go@v6
         with:
@@ -30,12 +31,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04"]
+        os: ["alluvial-finance-k8s-runners"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+      - uses: ./.github/actions/setup-runner-tools
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -49,7 +51,7 @@ jobs:
 
   lint:
     name: 'Linting tests'
-    runs-on: ubuntu-24.04
+    runs-on: alluvial-finance-k8s-runners
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6


### PR DESCRIPTION
## What
Migrate go-utils CI (`pr.yml` and `master.yml`) from GitHub-hosted runners to the BCE self-hosted runner scale set `alluvial-finance-k8s-runners`.

- Swap every `runs-on: ubuntu-24.04` / `runs-on: ubuntu-latest` and the matrix `os` value to `alluvial-finance-k8s-runners` in `pr.yml` and `master.yml`.
- Add `.github/actions/setup-runner-tools` composite action that installs `build-essential` (make/gcc/g++) and Node.js — tools the minimal self-hosted image lacks. Go comes from `actions/setup-go`; python3 is already present.
- Wire `setup-runner-tools` into the `unit-tests` and `integration-tests` jobs (both invoke `make`).
- Add `.github/actionlint.yaml` declaring the self-hosted runner label so actionlint recognises it.
- `release-drafter.yaml` is intentionally left on GitHub-hosted runners.

## Why
BS-4280: move CI compute onto the BCE self-hosted runner scale set.

## Validation
- `python3 yaml.safe_load` parses all changed YAML files successfully.
- Confirmed no `ubuntu-24.04` / `ubuntu-latest` labels remain in `pr.yml` or `master.yml`; `release-drafter.yaml` unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI jobs to run on a dedicated self-hosted runner pool for build, lint, unit, and integration checks.
  * Added a shared setup step that installs required build tools and configures the Node.js version used in runner environments.
  * Adjusted workflow configuration to match the new runner label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->